### PR TITLE
Add cmdline option to pass travel height while traveling between objects

### DIFF
--- a/lib/Slic3r/Print.pm
+++ b/lib/Slic3r/Print.pm
@@ -17,6 +17,15 @@ use Slic3r::Print::State ':steps';
 use Slic3r::Surface qw(S_TYPE_BOTTOM);
 
 our $status_cb;
+our $travel_height;
+
+sub set_travel_height {
+    my ($class, $th) = @_;
+    $travel_height = $th; 
+}
+sub travel_height {
+    return $travel_height;
+}
 
 sub set_status_cb {
     my ($class, $cb) = @_;

--- a/lib/Slic3r/Print/Simple.pm
+++ b/lib/Slic3r/Print/Simple.pm
@@ -57,6 +57,10 @@ has 'output_file' => (
     is      => 'rw',
 );
 
+has 'travel_height' => (
+    is      => 'rw',
+);
+
 sub _bed_polygon {
     my ($self) = @_;
     
@@ -110,6 +114,9 @@ sub _before_export {
     my ($self) = @_;
     
     $self->_print->set_status_cb($self->status_cb);
+    if ($self->travel_height) {
+        $self->_print->set_travel_height($self->travel_height);
+    }
     $self->_print->validate;
 }
 

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -64,7 +64,8 @@ my %cli_options = ();
         'duplicate-grid=s'      => \$opt{duplicate_grid},
         'print-center=s'        => \$opt{print_center},
         'dont-arrange'          => \$opt{dont_arrange},
-        
+        'travel-height=f'       => \$opt{travel_height},
+
         # legacy options, ignored
         'no-plater'             => \$opt{no_plater},
         'gui-mode=s'            => \$opt{gui_mode},
@@ -309,6 +310,7 @@ if (@ARGV) {  # slicing from command line
             duplicate_grid  => $opt{duplicate_grid} // [1,1],
             print_center    => $opt{print_center},
             dont_arrange    => $opt{dont_arrange}   // 0,
+            travel_height   => $opt{travel_height},
             status_cb       => sub {
                 my ($percent, $message) = @_;
                 printf "=> %s\n", $message;


### PR DESCRIPTION
Instead of callink $codegen-travel_to() only for the second object and so on, call it for all objecte, including the first one. This will output a travel move to the origin of the first object at the specified travel height, avoiding collision with the well walls if for example the user has for some reason moved the nozzle inside a well before starting the print.
When printing models in a wellplate, the bed has to be lowered before traveling to the starting position of the next object.
